### PR TITLE
set locale to C.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:bionic
 
 ENV AWSCLI_VERSION "1.16.84"
+ENV LC_ALL "C.UTF-8"
 
 RUN apt-get update \
  && apt-get upgrade -y \


### PR DESCRIPTION
so that the filename with utf-8 encodings are supported
e.g. in aws s3 cp münchen.css s3://some-bucket